### PR TITLE
Add operant-mcp to MCP Servers list

### DIFF
--- a/README.md
+++ b/README.md
@@ -11793,6 +11793,9 @@ Once configured, MCP enables AI assistants to:
 3889. **[actual-mcp-server](https://github.com/agigante80/actual-mcp-server)** - ⭐ 10
    Docker MCP server connecting MCP clients (tested with LibreChat/LobeChat) to Actual Budget for natural-language budgeting, transaction management, and financial insights.
 
+3890. **[operant-mcp](https://github.com/operantlabs/operant-mcp)** - ⭐ 0
+   Security testing MCP server with 51 tools for penetration testing, network forensics, memory analysis, and vulnerability assessment.
+
 ### MCP Clients
 
 *MCP client applications that connect to MCP servers*

--- a/data/projects.json
+++ b/data/projects.json
@@ -88985,6 +88985,29 @@
       "category": "servers",
       "owner": "agigante80",
       "archived": false
+    },
+    {
+      "name": "operant-mcp",
+      "full_name": "operantlabs/operant-mcp",
+      "description": "Security testing MCP server with 51 tools for penetration testing, network forensics, memory analysis, and vulnerability assessment.",
+      "url": "https://github.com/operantlabs/operant-mcp",
+      "stars": 0,
+      "language": "TypeScript",
+      "updated_at": "2026-03-25T00:00:00+00:00",
+      "created_at": "2025-01-01T00:00:00+00:00",
+      "topics": [
+        "mcp",
+        "security",
+        "penetration-testing",
+        "vulnerability-assessment",
+        "network-forensics",
+        "memory-analysis",
+        "model-context-protocol",
+        "typescript"
+      ],
+      "category": "servers",
+      "owner": "operantlabs",
+      "archived": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds [operant-mcp](https://github.com/operantlabs/operant-mcp) to the MCP Servers list and `data/projects.json`
- Security testing MCP server with 51 tools for penetration testing, network forensics, memory analysis, and vulnerability assessment
- TypeScript, MIT license