### PR TITLE
Add @worldcitisim/mcp-esim

### DIFF
--- a/data/projects.json
+++ b/data/projects.json
@@ -1,6 +1,6 @@
 {
   "last_updated": "2026-06-02T06:34:46.842041",
-  "total": 4810,
+  "total": 4811,
   "projects": [
     {
       "name": "ECC",
@@ -106048,6 +106048,27 @@
       ],
       "category": "servers",
       "owner": "finmap-org",
+      "archived": false
+    },
+    {
+      "name": "worldcitisim-frontend",
+      "full_name": "easyname889/worldcitisim-frontend",
+      "description": "Travel eSIM MCP server for 193 countries + UK SMS verification numbers. Stripe + Bitcoin checkout, QR delivered by email in ~30s. Anonymous, no API key needed.",
+      "url": "https://github.com/easyname889/worldcitisim-frontend",
+      "stars": 0,
+      "language": "TypeScript",
+      "updated_at": "2026-06-02T00:00:00+00:00",
+      "created_at": "2025-01-01T00:00:00+00:00",
+      "topics": [
+        "mcp",
+        "esim",
+        "travel",
+        "stripe",
+        "bitcoin",
+        "mcp-server"
+      ],
+      "category": "servers",
+      "owner": "easyname889",
       "archived": false
     }
   ]


### PR DESCRIPTION
WorldCitiSim MCP server for travel eSIMs (193 countries + UK SMS verification numbers). Stripe + Bitcoin checkout, QR delivered by email in ~30s. Anonymous, no API key needed.

Live: https://worldcitisim.com/developers
npm: https://www.npmjs.com/package/@worldcitisim/mcp-esim
MCP Registry: com.worldcitisim/mcp-esim