### PR TITLE
Add Neuron MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ Once configured, MCP enables AI assistants to:
 
 ---
 
-## 📚 Projects (4952 total)
+## 📚 Projects (4953 total)
 
 > Last updated: **2026-06-28**
 
@@ -14011,6 +14011,9 @@ Once configured, MCP enables AI assistants to:
 
 4627. **[mcp-server](https://github.com/finmap-org/mcp-server)** - ⭐ 10
    The finmap.org MCP server provides comprehensive historical data from the US, UK, Russian and Turkish stock exchanges. Access sectors, tickers, company profiles, market cap, volume, value, and trade counts, as well as treemap and histogram visualizations
+
+4628. **[neuron](https://github.com/conquext/neuron)** - ⭐ 0
+   AI-powered WhatsApp chatbot platform with 196 MCP tools for building, deploying, and managing intelligent chatbots. Features knowledge bases, campaigns, broadcasts, contact management, and multi-model AI support.
 
 ### MCP Clients
 

--- a/data/projects.json
+++ b/data/projects.json
@@ -1,6 +1,6 @@
 {
   "last_updated": "2026-06-28T06:20:07.978003",
-  "total": 4952,
+  "total": 4953,
   "projects": [
     {
       "name": "ECC",
@@ -110141,6 +110141,31 @@
       ],
       "category": "servers",
       "owner": "finmap-org",
+      "archived": false
+    },
+    {
+      "name": "neuron",
+      "full_name": "conquext/neuron",
+      "description": "AI-powered WhatsApp chatbot platform with 196 MCP tools for building, deploying, and managing intelligent chatbots. Features knowledge bases, campaigns, broadcasts, contact management, and multi-model AI support.",
+      "url": "https://github.com/conquext/neuron",
+      "stars": 0,
+      "language": "TypeScript",
+      "updated_at": "2026-06-28T19:56:46+00:00",
+      "created_at": "2026-03-15T06:50:04+00:00",
+      "topics": [
+        "ai-agents",
+        "ai-chatbot",
+        "chatbot",
+        "conversational-ai",
+        "mcp-server",
+        "model-context-protocol",
+        "whatsapp-api",
+        "whatsapp-bot",
+        "whatsapp-business",
+        "whatsapp-chatbot"
+      ],
+      "category": "servers",
+      "owner": "conquext",
       "archived": false
     }
   ]


### PR DESCRIPTION
## Summary

- Adds [Neuron](https://github.com/conquext/neuron) to the MCP Servers section in both `README.md` and `data/projects.json`
- Neuron is an AI-powered WhatsApp chatbot platform with 196 MCP tools for building, deploying, and managing intelligent chatbots
- Features include knowledge bases, campaigns, broadcasts, contact management, and multi-model AI support

## Changes

- `README.md`: Added entry #4628 in the MCP Servers section, updated total project count from 4952 to 4953
- `data/projects.json`: Added Neuron project entry with full metadata (TypeScript, relevant topics, category: servers)

## Checklist

- [x] Project is MCP-related (MCP server with 196 tools)
- [x] Project has a README
- [x] Project is not archived
- [x] Entry follows existing format in both README.md and projects.json
- [x] Total count updated
